### PR TITLE
Sphinx docs now use :start-after: and :end-before: to  identify code segments

### DIFF
--- a/gh_pages/_source/tesseract_collision_doc.rst
+++ b/gh_pages/_source/tesseract_collision_doc.rst
@@ -36,7 +36,8 @@ Create Contact Checker
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 22
+   :start-after: // Create Collision Manager
+   :end-before: // Add box to checker
 
 There are several available contact checkers.
 
@@ -68,42 +69,48 @@ Add collision object in a enabled state
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 25-34
+   :start-after: // Add box to checker
+   :end-before: // Add thin box to checker which is disabled
 
 Add collision object in a disabled state
 """"""""""""""""""""""""""""""""""""""""
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 37-46
+   :start-after: // Add thin box to checker which is disabled
+   :end-before: // Add second box to checker, but convert to convex hull mesh.
 
 Add another collision object
 """"""""""""""""""""""""""""
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 49-69
+   :start-after: // This is required because convex hull cannot have multiple faces on the same plane.
+   :end-before: CONSOLE_BRIDGE_logInform("Test when object is inside another");
 
 Set the active collision object's
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 72
+   :start-after: CONSOLE_BRIDGE_logInform("Test when object is inside another");
+   :end-before: checker.setContactDistanceThreshold(0.1);
 
 Set the contact distance threshold
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 73
+   :start-after: checker.setActiveCollisionObjects({ "box_link", "second_box_link" });
+   :end-before: // Set the collision object transforms
 
 Set the collision object's transform
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 76-82
+   :start-after: // Set the collision object transforms
+   :end-before: // Perform collision check
 
 Perform collision check
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,14 +121,21 @@ Perform collision check
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 85-89
+   :start-after: // Perform collision check
+   :end-before: CONSOLE_BRIDGE_logInform("Has collision: %s", toString(result_vector.empty()).c_str());
 
 Set the collision object's transform
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 98,102
+   :start-after: CONSOLE_BRIDGE_logInform("Test object is out side the contact distance");
+   :end-before: result.clear();
+
+.. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
+   :language: c++
+   :start-after: result_vector.clear();
+   :end-before: // Check for collision
 
 Perform collision check
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,14 +146,17 @@ Perform collision check
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 103
+   :start-after: // Check for collision after moving object
+   :end-before: CONSOLE_BRIDGE_logInform("Has collision: %s", toString(result_vector.empty()).c_str());
 
 Change contact distance threshold
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 112
+   :start-after: // Set higher contact distance threshold
+   :end-before: // Check for contact with new threshold
+
 
 Perform collision check
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -150,4 +167,5 @@ Perform collision check
 
 .. literalinclude:: ../../tesseract/tesseract_collision/examples/box_box_example.cpp
    :language: c++
-   :lines: 113
+   :start-after: // Check for contact with new threshold
+   :end-before: CONSOLE_BRIDGE_logInform("Has collision: %s", toString(result_vector.empty()).c_str());

--- a/gh_pages/_source/tesseract_geometry_doc.rst
+++ b/gh_pages/_source/tesseract_geometry_doc.rst
@@ -35,37 +35,43 @@ Example Explanation
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 11
+      :start-after: // Primitive Shapes
+      :end-before: auto cone = std::make_shared<tesseract_geometry::Cone>(1, 1);
 
 #. Create a cone.
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 12
+      :start-after: auto box = std::make_shared<tesseract_geometry::Box>(1, 1, 1);
+      :end-before: auto cylinder = std::make_shared<tesseract_geometry::Cylinder>(1, 1);
 
 #. Create a cylinder.
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 13
+      :start-after: auto cone = std::make_shared<tesseract_geometry::Cone>(1, 1);
+      :end-before: auto plane = std::make_shared<tesseract_geometry::Plane>(1, 1, 1, 1);
 
 #. Create a plane.
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 14
+      :start-after: auto cylinder = std::make_shared<tesseract_geometry::Cylinder>(1, 1);
+      :end-before: auto sphere = std::make_shared<tesseract_geometry::Sphere>(1);
 
 #. Create a sphere.
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 15
+      :start-after: auto plane = std::make_shared<tesseract_geometry::Plane>(1, 1, 1, 1);
+      :end-before: // Manually create mesh
 
 #. Create a mesh.
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 16-21
+      :start-after: // Manually create mesh
+      :end-before: // Manually create signed distance field mesh
 
    .. Note::
 
@@ -79,7 +85,8 @@ Example Explanation
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 24-27
+      :start-after: // Manually create signed distance field mesh
+      :end-before: // Manually create convex mesh
 
    .. Note::
 
@@ -93,17 +100,19 @@ Example Explanation
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 30-33
+      :start-after: // Manually create convex mesh
+      :end-before: // Create an octree
 
    .. Note::
 
       This shows how to create a convex mesh provided vertices and faces. You may also use utilities in tesseract_scene_graph mesh parser to load meshes from file.
 
-#. Create a octree.
+#. Create an octree.
 
    .. literalinclude:: ../../tesseract/tesseract_geometry/examples/create_geometries_example.cpp
       :language: c++
-      :lines: 35-37
+      :start-after: // Create an octree
+      :end-before: }
 
    .. Note::
 

--- a/gh_pages/_source/tesseract_scene_graph_doc.rst
+++ b/gh_pages/_source/tesseract_scene_graph_doc.rst
@@ -52,6 +52,7 @@ Examples
 #. :ref:`Parse Mesh <ex4>`
 
 .. _ex1:
+
 Building A Scene Graph
 ======================
 
@@ -66,7 +67,8 @@ Create Scene Graph
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 23
+   :start-after: // Create scene graph
+   :end-before: // Create links
 
 Add Links
 ^^^^^^^^^
@@ -75,13 +77,15 @@ Create the links. The links are able to be configured see Link documentation.
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
   :language: c++
-  :lines: 25-29
+  :start-after: // Create links
+  :end-before: // Add links
 
 Add the links to the scene graph
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 31-35
+   :start-after: // Add links
+   :end-before: // Create joints
 
 Add Joints
 ^^^^^^^^^^
@@ -90,13 +94,15 @@ Create the joints. The links are able to be configured see Joint documentation.
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 37-59
+   :start-after: // Create joints
+   :end-before: // Add joints
 
 Add the joints to the scene graph_acyclic_tree_example
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 61-64
+   :start-after: // Add joints
+   :end-before: // Check getAdjacentLinkNames Method
 
 Inspect Scene Graph
 ^^^^^^^^^^^^^^^^^^^
@@ -105,43 +111,50 @@ Get the adjacent links for **link_3** and print to terminal
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 67-69
+   :start-after: // Check getAdjacentLinkNames Method
+   :end-before: // Check getInvAdjacentLinkNames Method
 
 Get the inverse adjacent links for **link_3** and print to terminal
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 72-74
+   :start-after: // Check getInvAdjacentLinkNames Method
+   :end-before: // Check getLinkChildrenNames
 
 Get child link names for link **link_3** and print to terminal
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 77-79
+   :start-after: // Check getLinkChildrenNames
+   :end-before: // Check getJointChildrenNames
 
 Get child link names for joint **joint_1** and print to terminal
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 82-84
+   :start-after: // Check getJointChildrenNames
+   :end-before: // Save Graph
 
 Save the graph to a file for visualization
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 87
+   :start-after: // Save Graph
+   :end-before: // Test if the graph is Acyclic
 
 Test if the graph is Acyclic and print to terminal
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 90-91
+   :start-after: // Test if the graph is Acyclic
+   :end-before: // Test if the graph is Tree
 
 Test if the graph is a tree and print to terminal
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 94-95
+   :start-after: // Test if the graph is Tree
+   :end-before: // Test for unused links
 
 Detect Unused Links
 ^^^^^^^^^^^^^^^^^^^
@@ -150,13 +163,15 @@ First add a link but do not create joint and check if it is a tree. It should re
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 98-101
+   :start-after: // Test for unused links
+   :end-before: // Remove unused link
 
 Remove link and check if it is a tree. It should return true.
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 103-105
+   :start-after: // Remove unused link
+   :end-before: // Add new joint
 
 Create Acyclic Graph
 ^^^^^^^^^^^^^^^^^^^^
@@ -167,34 +182,40 @@ Add joint connecting **link_5** and **link_4** to create an Acyclic graph_acycli
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 107-112
+   :start-after: // Add new joint
+   :end-before: // Save new graph
 
 Save the Acyclic graph
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 115
+   :start-after: // Save new graph
+   :end-before: // Test again if the graph is Acyclic
 
 Test to confirm it is acyclic, should return true.
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 118-119
+   :start-after: // Test again if the graph is Acyclic
+   :end-before: // Test again if the graph is Tree
 
 Test if it is a tree, should return false.
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 122-123
+   :start-after: // Test again if the graph is Tree
+   :end-before: // Get Shortest Path
 
 Get Shortest Path
 ^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
    :language: c++
-   :lines: 126-127
+   :start-after: // Get Shortest Path
+   :end-before: }
 
 .. _ex2:
+
 Create Scene Graph from URDF
 ============================
 
@@ -208,38 +229,44 @@ Create Resource Locator
 
 Because this is ROS agnostic you need to provide a resource locator for interpreting **package:/**.
 
-.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
+.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/load_urdf_example.cpp
    :language: c++
-   :lines: 20-42
+   :start-after: // Define a resource locator function
+   :end-before: int main(int /*argc*/, char** /*argv*/)
 
 Load URDF
 ^^^^^^^^^
 
 Get the file path to the urdf file
 
-.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
+.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/load_urdf_example.cpp
    :language: c++
-   :lines: 49
+   :start-after: // Get the urdf file path
+   :end-before: // Create scene graph
 
 Create scene graph from urdf
 
-.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
+.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/load_urdf_example.cpp
    :language: c++
-   :lines: 51-52
+   :start-after: // Create scene graph
+   :end-before: // Print information
 
 Print information about the scene graph to the terminal
 
-.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
+.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/load_urdf_example.cpp
    :language: c++
-   :lines: 54-57
+   :start-after: // Print information
+   :end-before: // Save graph
 
 Save the graph to a file.
 
-.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
+.. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/load_urdf_example.cpp
    :language: c++
-   :lines: 60
+   :start-after: // Save graph
+   :end-before: }
 
 .. _ex3:
+
 Parse SRDF adding Allowed Collision Matrix to Graph
 ===================================================
 
@@ -255,7 +282,8 @@ Because this is ROS agnostic you need to provide a resource locator for interpre
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
    :language: c++
-   :lines: 22-47
+   :start-after: // Define a resource locator function
+   :end-before: int main(int /*argc*/, char** /*argv*/)
 
 Load URDF and SRDF
 ^^^^^^^^^^^^^^^^^^
@@ -264,33 +292,39 @@ Get the file path to the URDF and SRDF file
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
    :language: c++
-   :lines: 51-52
+   :start-after: // Get the urdf and srdf file paths
+   :end-before: // Create scene graph
 
 Create Scene Graph from URDF
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
    :language: c++
-   :lines: 54-55
+   :start-after: // Create scene graph
+   :end-before: // Parse the srdf
 
 Parse SRDF
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
    :language: c++
-   :lines: 57-59
+   :start-after: // Parse the srdf
+   :end-before: // Add allowed collision matrix to scene graph
 
 Add Allowed Collision Matrix to Scene Graph
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
    :language: c++
-   :lines: 61
+   :start-after: // Add allowed collision matrix to scene graph
+   :end-before: // Get info about allowed collision matrix
 
 Methods for getting Allowed Collision Matrix from Scene Graph
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
    :language: c++
-   :lines: 63-64
+   :start-after: // Get info about allowed collision matrix
+   :end-before: const AllowedCollisionMatrix::AllowedCollisionEntries& acm_entries = acm->getAllAllowedCollisions();
 
 .. _ex4:
+
 Parse Mesh from file
 ====================
 
@@ -306,11 +340,13 @@ Mesh files can contain multiple meshes. This is a critical difference between Mo
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/parse_mesh_example.cpp
    :language: c++
-   :lines: 10-11
+   :start-after: // Create meshes
+   :end-before: // Print mesh information
 
 Print Mesh Information to Terminal
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../tesseract/tesseract_scene_graph/examples/parse_mesh_example.cpp
    :language: c++
-   :lines: 13-17
+   :start-after: // Print mesh information
+   :end-before: }

--- a/tesseract/tesseract_collision/examples/box_box_example.cpp
+++ b/tesseract/tesseract_collision/examples/box_box_example.cpp
@@ -104,6 +104,8 @@ int main(int /*argc*/, char** /*argv*/)
   result_vector.clear();
 
   checker.setCollisionObjectsTransform(location);
+
+  // Check for collision after moving object
   checker.contactTest(result, ContactTestType::CLOSEST);
   flattenResults(std::move(result), result_vector);
 
@@ -113,7 +115,10 @@ int main(int /*argc*/, char** /*argv*/)
   result.clear();
   result_vector.clear();
 
+  // Set higher contact distance threshold
   checker.setContactDistanceThreshold(0.25);
+
+  // Check for contact with new threshold
   checker.contactTest(result, ContactTestType::CLOSEST);
   flattenResults(std::move(result), result_vector);
 

--- a/tesseract/tesseract_geometry/examples/create_geometries_example.cpp
+++ b/tesseract/tesseract_geometry/examples/create_geometries_example.cpp
@@ -20,7 +20,7 @@ int main(int /*argc*/, char** /*argv*/)
   // Next fill out vertices and triangles
   auto mesh = std::make_shared<tesseract_geometry::Mesh>(mesh_vertices, mesh_faces);
 
-  // Manually create mesh
+  // Manually create signed distance field mesh
   std::shared_ptr<const tesseract_common::VectorVector3d> sdf_vertices =
       std::make_shared<const tesseract_common::VectorVector3d>();
   std::shared_ptr<const Eigen::VectorXi> sdf_faces = std::make_shared<const Eigen::VectorXi>();
@@ -34,7 +34,7 @@ int main(int /*argc*/, char** /*argv*/)
   // Next fill out vertices and triangles
   auto convex_mesh = std::make_shared<tesseract_geometry::ConvexMesh>(convex_vertices, convex_faces);
 
+  // Create an octree
   std::shared_ptr<const octomap::OcTree> octree;
-  // Next populate octree
   auto octree_t = std::make_shared<tesseract_geometry::Octree>(octree, tesseract_geometry::Octree::SubType::BOX);
 }

--- a/tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
+++ b/tesseract/tesseract_scene_graph/examples/build_scene_graph_example.cpp
@@ -17,20 +17,24 @@ int main(int /*argc*/, char** /*argv*/)
 {
   console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO);
 
+  // Create scene graph
   SceneGraph g;
 
+  // Create links
   Link link_1("link_1");
   Link link_2("link_2");
   Link link_3("link_3");
   Link link_4("link_4");
   Link link_5("link_5");
 
+  // Add links
   g.addLink(link_1);
   g.addLink(link_2);
   g.addLink(link_3);
   g.addLink(link_4);
   g.addLink(link_5);
 
+  // Create joints
   Joint joint_1("joint_1");
   joint_1.parent_to_joint_origin_transform.translation()(0) = 1.25;
   joint_1.parent_link_name = "link_1";
@@ -55,6 +59,7 @@ int main(int /*argc*/, char** /*argv*/)
   joint_4.child_link_name = "link_5";
   joint_4.type = JointType::REVOLUTE;
 
+  // Add joints
   g.addJoint(joint_1);
   g.addJoint(joint_2);
   g.addJoint(joint_3);
@@ -97,10 +102,12 @@ int main(int /*argc*/, char** /*argv*/)
   is_tree = g.isTree();
   CONSOLE_BRIDGE_logInform(toString(is_tree).c_str());
 
+  // Remove unused link
   g.removeLink(link_6.getName());
   is_tree = g.isTree();
   CONSOLE_BRIDGE_logInform(toString(is_tree).c_str());
 
+  // Add new joint
   Joint joint_5("joint_5");
   joint_5.parent_to_joint_origin_transform.translation()(1) = 1.25;
   joint_5.parent_link_name = "link_5";
@@ -108,14 +115,14 @@ int main(int /*argc*/, char** /*argv*/)
   joint_5.type = JointType::CONTINUOUS;
   g.addJoint(joint_5);
 
-  // Save Graph
+  // Save new graph
   g.saveDOT("/tmp/graph_acyclic_not_tree_example.dot");
 
-  // Test if the graph is Acyclic
+  // Test again if the graph is Acyclic
   is_acyclic = g.isAcyclic();
   std::cout << toString(is_acyclic).c_str();
 
-  // Test if the graph is Tree
+  // Test again if the graph is Tree
   is_tree = g.isTree();
   CONSOLE_BRIDGE_logInform(toString(is_tree).c_str());
 

--- a/tesseract/tesseract_scene_graph/examples/load_urdf_example.cpp
+++ b/tesseract/tesseract_scene_graph/examples/load_urdf_example.cpp
@@ -14,6 +14,7 @@ std::string toString(const SceneGraph::Path& path)
 
 std::string toString(bool b) { return b ? "true" : "false"; }
 
+// Define a resource locator function
 std::string locateResource(const std::string& url)
 {
   std::string mod_url = url;
@@ -43,16 +44,19 @@ std::string locateResource(const std::string& url)
 
 int main(int /*argc*/, char** /*argv*/)
 {
+  // Get the urdf file path
   std::string urdf_file = std::string(TESSERACT_SUPPORT_DIR) + "/urdf/lbr_iiwa_14_r820.urdf";
 
+  // Create scene graph
   ResourceLocatorFn locator = locateResource;
   SceneGraph::Ptr g = parseURDFFile(urdf_file, locator);
 
+  // Print information
   CONSOLE_BRIDGE_logInform(std::to_string(g->getJoints().size()).c_str());
   CONSOLE_BRIDGE_logInform(std::to_string(g->getLinks().size()).c_str());
   CONSOLE_BRIDGE_logInform(toString(g->isTree()).c_str());
   CONSOLE_BRIDGE_logInform(toString(g->isAcyclic()).c_str());
 
-  // Save Graph
+  // Save graph
   g->saveDOT("/tmp/tesseract_urdf_import.dot");
 }

--- a/tesseract/tesseract_scene_graph/examples/parse_mesh_example.cpp
+++ b/tesseract/tesseract_scene_graph/examples/parse_mesh_example.cpp
@@ -7,9 +7,11 @@ using namespace tesseract_scene_graph;
 
 int main(int /*argc*/, char** /*argv*/)
 {
+  // Create meshes
   std::string mesh_file = std::string(TESSERACT_SUPPORT_DIR) + "/meshes/sphere_p25m.dae";
   std::vector<tesseract_geometry::Mesh::Ptr> meshes = createMeshFromPath<tesseract_geometry::Mesh>(mesh_file);
 
+  // Print mesh information
   CONSOLE_BRIDGE_logInform("Number of meshes: %f", meshes.size());
   CONSOLE_BRIDGE_logInform("Mesh #1 Triangle Count: %f", meshes[0]->getTriangleCount());
   CONSOLE_BRIDGE_logInform("Mesh #1 Triangle Count: %f", meshes[0]->getVerticeCount());

--- a/tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
+++ b/tesseract/tesseract_scene_graph/examples/parse_srdf_example.cpp
@@ -16,6 +16,7 @@ std::string toString(const SceneGraph::Path& path)
 
 std::string toString(bool b) { return b ? "true" : "false"; }
 
+// Define a resource locator function
 std::string locateResource(const std::string& url)
 {
   std::string mod_url = url;
@@ -45,18 +46,23 @@ std::string locateResource(const std::string& url)
 
 int main(int /*argc*/, char** /*argv*/)
 {
+  // Get the urdf and srdf file paths
   std::string urdf_file = std::string(TESSERACT_SUPPORT_DIR) + "/urdf/lbr_iiwa_14_r820.urdf";
   std::string srdf_file = std::string(TESSERACT_SUPPORT_DIR) + "/urdf/lbr_iiwa_14_r820.srdf";
 
+  // Create scene graph
   ResourceLocatorFn locator = locateResource;
   SceneGraph::Ptr g = parseURDFFile(urdf_file, locator);
 
+  // Parse the srdf
   SRDFModel srdf;
   bool success = srdf.initFile(*g, srdf_file);
   CONSOLE_BRIDGE_logInform("SRDF loaded: %s", toString(success).c_str());
 
+  // Add allowed collision matrix to scene graph
   processSRDFAllowedCollisions(*g, srdf);
 
+  // Get info about allowed collision matrix
   AllowedCollisionMatrix::ConstPtr acm = g->getAllowedCollisionMatrix();
   const AllowedCollisionMatrix::AllowedCollisionEntries& acm_entries = acm->getAllAllowedCollisions();
   CONSOLE_BRIDGE_logInform("ACM Number of entries: %d", acm_entries.size());


### PR DESCRIPTION
In the docs were code segments were identified with hard coded line numbers, the :start-after: and :end-before: directives were inserted instead. Comments were added in the code as needed to enable this change. 

Not sure if you want these changes as is or not, but it at least gives you a reference to what you were asking about