### PR TITLE
Fix SWIG Python data types in srdf_model.i

### DIFF
--- a/tesseract_python/tesseract_python/swig/tesseract_python.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_python.i
@@ -71,9 +71,13 @@
 %template(vector_string) std::vector<std::string>;
 %template(pair_string) std::pair<std::string, std::string>;
 %template(vector_pair_string) std::vector<std::pair<std::string, std::string> >;
+%template(map_string_vector_pair_string) std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>>;
 
 %template(vector_double) std::vector<double>;
-%template(map_string_vector_double) std::map<std::string, std::vector<double> >;
+%template(map_string_vector_double) std::unordered_map<std::string, std::vector<double> >;
+%template(map_string_double) std::unordered_map<std::string, double>;
+%template(map_string_map_string_double) std::unordered_map<std::string, std::unordered_map<std::string, double> >;
+%template(map_string_map_string_map_string_double) std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::string, double> > >;
 
 %include "tesseract_common/types.i"
 %include "tesseract_common/status_code.i"

--- a/tesseract_python/tesseract_python/swig/tesseract_scene_graph/srdf_model.i
+++ b/tesseract_python/tesseract_python/swig/tesseract_scene_graph/srdf_model.i
@@ -32,6 +32,9 @@
 
 %shared_ptr(tesseract_scene_graph::SRDFModel)
 
+%template(map_string_isometry3d) std::unordered_map<std::string, Eigen::Isometry3d>;
+//%template(map_string_opwkinparams) std::unordered_map<std::string, tesseract_scene_graph::SRDFModel::OPWKinematicParameters>;
+
 namespace tesseract_scene_graph
 {
 
@@ -75,8 +78,8 @@ public:
   bool saveToFile(const std::string& file_path) const;
 
   /** @brief Get the name of this model */
-  const std::string& getName() const;
-  std::string& getName();
+  const std::string getName() const;
+  std::string getName();
 
   /** @brief Get the list of pairs of links that need not be checked for collisions (because they can never touch given the geometry and kinematics of the robot) */
   const AllowedCollisionMatrix& getAllowedCollisionMatrix() const;

--- a/tesseract_python/tesseract_python/tests/test_srdf_parser.py
+++ b/tesseract_python/tesseract_python/tests/test_srdf_parser.py
@@ -24,20 +24,18 @@ def test_environment():
     assert str(t_srdf.getName()) == "abb_irb2400"
 
     chain_groups = t_srdf.getChainGroups()
-    assert len(groups) == 1
-    group = chain_groups.find("manipulator")
-    assert group.first == "manipulator"
-    assert group.second == ("base_link", "tool0")
+    assert len(chain_groups) == 1
+    group = chain_groups["manipulator"]
+    assert(len(group) == 1)
+    assert group[0] == ("base_link", "tool0")
 
     # Group state now
     group_states = t_srdf.getGroupStates()
     assert len(group_states) == 1
-    group_state = group_states.find("manipulator")
-    assert group_state.first == "manipulator"
-    state = group_state.second.find("all-zeros")
-    assert state.first == "all-zeros"
-    for i in range(1, 7):
-        assert state.second["joint_{}".format(i)] == (0.0,)
+    group_state = group_states["manipulator"]
+    state = group_state["all-zeros"]
+    for i in range(1, 7):        
+        assert state["joint_{}".format(i)] == 0.0
 
 
 class TesseractSupportResourceLocator(tesseract.ResourceLocator):


### PR DESCRIPTION
The unit tests are passing with these changes. I wasn't able to wrap `std::unordered_map<std::string, tesseract_scene_graph::SRDFModel::OPWKinematicParameters>` because it uses a nested class, which SWIG doesn't handle well. Can we move OPWKinematicParameters outside of the SRDFModel class?