### PR TITLE
Tesseract collision yaml extensions

### DIFF
--- a/tesseract_collision/core/include/tesseract_collision/core/yaml_extensions.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/yaml_extensions.h
@@ -121,6 +121,70 @@ struct convert<tesseract_collision::ContactManagerConfig>
   }
 };
 
+//=========================== ContactRequest ===========================
+template <>
+struct convert<tesseract_collision::ContactRequest>
+{
+  static Node encode(const tesseract_collision::ContactRequest& rhs)
+  {
+    Node node;
+    
+    node["type"] = rhs.type;
+    node["calculate_penetration"] = rhs.calculate_penetration;
+    node["calculate_distance"] = rhs.calculate_distance;
+    node["contact_limit"] = rhs.contact_limit;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_collision::ContactRequest& rhs) 
+  {
+    if (const YAML::Node& n = node["type"])
+      rhs.type = n.as<tesseract_collision::ContractRequestType>();
+    
+    if (const YAML::Node& n = node["calculate_penetration"])
+      rhs.calculate_penetration = n.as<bool>();
+    
+    if (const YAML::Node& n = node["calculate_distance"])
+      rhs.calculate_distance = n.as<bool>();
+    
+    if (const YAML::Node& n = node["contact_limit"])
+      rhs.contact_limit = n.as<long>();
+
+    return true;
+  }
+};
+
+//=========================== CollisionCheckConfig ===========================
+template <>
+struct convert<tesseract_collision::CollisionCheckConfig>
+{
+  static Node encode(const tesseract_collision::CollisionCheckConfig& rhs)
+  {
+    Node node;
+    
+    node["contact_request"] = YAML::convert<tesseract_collision::ContactRequest>::encode(&rhs.contact_request);
+    node["type"] = rhs.type;
+    node["longest_valid_segment_length"] = rhs.longest_valid_segment_length;
+    node["check_program_mode"] = rhs.check_program_mode;
+    
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_collision::CollisionCheckConfig& rhs) 
+  {
+    if (const YAML::Node& n = node["contact_request"])
+      YAML::convert<tesseract_collision::ContactRequest>::decode(node["contact_request"], &rhs.contact_request);
+    if (const YAML::Node& n = node["type"]) 
+      rhs.type = node["type"];
+    if (const YAML::Node& n = node["longest_valid_segment_length"])
+      rhs.longest_valid_segment_length = node["longest_valid_segment_length"];
+    if (const YAML::Node& n = node["check_program_mode"]) 
+      rhs.check_program_mode = node["check_program_mode"];
+    return true;
+  }
+};
+
+
 }  // namespace YAML
 
 #endif  // TESSERACT_COLLISION_CORE_YAML_EXTENSIONS_H

--- a/tesseract_collision/core/include/tesseract_collision/core/yaml_extensions.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/yaml_extensions.h
@@ -76,6 +76,132 @@ struct convert<tesseract_collision::ACMOverrideType>
   }
 };
 
+//=========================== ContactTestType Enum ===========================
+template <>
+struct convert<tesseract_collision::ContactTestType>
+{
+  static Node encode(const tesseract_collision::ContactTestType& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<tesseract_collision::ContactTestType, std::string> m = {
+      { tesseract_collision::ContactTestType::FIRST, "FIRST" },
+      { tesseract_collision::ContactTestType::CLOSEST, "CLOSEST" },
+      { tesseract_collision::ContactTestType::ALL, "ALL" },
+      { tesseract_collision::ContactTestType::LIMITED, "LIMITED" }
+    };
+    // LCOV_EXCL_STOP
+    return Node(m.at(rhs));
+  }
+
+  static bool decode(const Node& node, tesseract_collision::ContactTestType& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<std::string, tesseract_collision::ContactTestType> inv = {
+      { "FIRST", tesseract_collision::ContactTestType::FIRST },
+      { "CLOSEST", tesseract_collision::ContactTestType::CLOSEST },
+      { "ALL", tesseract_collision::ContactTestType::ALL },
+      { "LIMITED", tesseract_collision::ContactTestType::LIMITED }
+    };
+    // LCOV_EXCL_STOP
+
+    if (!node.IsScalar())
+      return false;
+
+    auto it = inv.find(node.Scalar());
+    if (it == inv.end())
+      return false;
+
+    rhs = it->second;
+    return true;
+  }
+};
+
+//=========================== CollisionEvaluatorType Enum ===========================
+template <>
+struct convert<tesseract_collision::CollisionEvaluatorType>
+{
+  static Node encode(const tesseract_collision::CollisionEvaluatorType& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<tesseract_collision::CollisionEvaluatorType, std::string> m = {
+      { tesseract_collision::CollisionEvaluatorType::NONE, "NONE" },
+      { tesseract_collision::CollisionEvaluatorType::DISCRETE, "DISCRETE" },
+      { tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE, "LVS_DISCRETE" },
+      { tesseract_collision::CollisionEvaluatorType::CONTINUOUS, "CONTINUOUS" },
+      { tesseract_collision::CollisionEvaluatorType::LVS_CONTINUOUS, "LVS_CONTINUOUS" }
+    };
+    // LCOV_EXCL_STOP
+    return Node(m.at(rhs));
+  }
+
+  static bool decode(const Node& node, tesseract_collision::CollisionEvaluatorType& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<std::string, tesseract_collision::CollisionEvaluatorType> inv = {
+      { "NONE", tesseract_collision::CollisionEvaluatorType::NONE },
+      { "DISCRETE", tesseract_collision::CollisionEvaluatorType::DISCRETE },
+      { "LVS_DISCRETE", tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE },
+      { "CONTINUOUS", tesseract_collision::CollisionEvaluatorType::CONTINUOUS },
+      { "LVS_CONTINUOUS", tesseract_collision::CollisionEvaluatorType::LVS_CONTINUOUS }
+    };
+    // LCOV_EXCL_STOP
+
+    if (!node.IsScalar())
+      return false;
+
+    auto it = inv.find(node.Scalar());
+    if (it == inv.end())
+      return false;
+
+    rhs = it->second;
+    return true;
+  }
+};
+
+//=========================== CollisionCheckProgramType Enum ===========================
+template <>
+struct convert<tesseract_collision::CollisionCheckProgramType>
+{
+  static Node encode(const tesseract_collision::CollisionCheckProgramType& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<tesseract_collision::CollisionCheckProgramType, std::string> m = {
+      { tesseract_collision::CollisionCheckProgramType::ALL, "ALL" },
+      { tesseract_collision::CollisionCheckProgramType::ALL_EXCEPT_START, "ALL_EXCEPT_START" },
+      { tesseract_collision::CollisionCheckProgramType::ALL_EXCEPT_END, "ALL_EXCEPT_END" },
+      { tesseract_collision::CollisionCheckProgramType::START_ONLY, "START_ONLY" },
+      { tesseract_collision::CollisionCheckProgramType::END_ONLY, "END_ONLY" },
+      { tesseract_collision::CollisionCheckProgramType::INTERMEDIATE_ONLY, "INTERMEDIATE_ONLY" }
+    };
+    // LCOV_EXCL_STOP
+    return Node(m.at(rhs));
+  }
+
+  static bool decode(const Node& node, tesseract_collision::CollisionCheckProgramType& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<std::string, tesseract_collision::CollisionCheckProgramType> inv = {
+      { "ALL", tesseract_collision::CollisionCheckProgramType::ALL },
+      { "ALL_EXCEPT_START", tesseract_collision::CollisionCheckProgramType::ALL_EXCEPT_START },
+      { "ALL_EXCEPT_END", tesseract_collision::CollisionCheckProgramType::ALL_EXCEPT_END },
+      { "START_ONLY", tesseract_collision::CollisionCheckProgramType::START_ONLY },
+      { "END_ONLY", tesseract_collision::CollisionCheckProgramType::END_ONLY },
+      { "INTERMEDIATE_ONLY", tesseract_collision::CollisionCheckProgramType::INTERMEDIATE_ONLY }
+    };
+    // LCOV_EXCL_STOP
+
+    if (!node.IsScalar())
+      return false;
+
+    auto it = inv.find(node.Scalar());
+    if (it == inv.end())
+      return false;
+
+    rhs = it->second;
+    return true;
+  }
+};
+
 //=========================== ContactManagerConfig ===========================
 template <>
 struct convert<tesseract_collision::ContactManagerConfig>
@@ -139,7 +265,7 @@ struct convert<tesseract_collision::ContactRequest>
   static bool decode(const Node& node, tesseract_collision::ContactRequest& rhs) 
   {
     if (const YAML::Node& n = node["type"])
-      rhs.type = n.as<tesseract_collision::ContractRequestType>();
+      rhs.type = n.as<tesseract_collision::ContactTestType>();
     
     if (const YAML::Node& n = node["calculate_penetration"])
       rhs.calculate_penetration = n.as<bool>();
@@ -162,7 +288,7 @@ struct convert<tesseract_collision::CollisionCheckConfig>
   {
     Node node;
     
-    node["contact_request"] = YAML::convert<tesseract_collision::ContactRequest>::encode(&rhs.contact_request);
+    node["contact_request"] = rhs.contact_request;
     node["type"] = rhs.type;
     node["longest_valid_segment_length"] = rhs.longest_valid_segment_length;
     node["check_program_mode"] = rhs.check_program_mode;
@@ -173,17 +299,18 @@ struct convert<tesseract_collision::CollisionCheckConfig>
   static bool decode(const Node& node, tesseract_collision::CollisionCheckConfig& rhs) 
   {
     if (const YAML::Node& n = node["contact_request"])
-      YAML::convert<tesseract_collision::ContactRequest>::decode(node["contact_request"], &rhs.contact_request);
+      rhs.contact_request = n.as<tesseract_collision::ContactRequest>();
     if (const YAML::Node& n = node["type"]) 
-      rhs.type = node["type"];
+      rhs.type = n.as<tesseract_collision::CollisionEvaluatorType>();
     if (const YAML::Node& n = node["longest_valid_segment_length"])
-      rhs.longest_valid_segment_length = node["longest_valid_segment_length"];
+      rhs.longest_valid_segment_length = n.as<double>();
     if (const YAML::Node& n = node["check_program_mode"]) 
-      rhs.check_program_mode = node["check_program_mode"];
+      rhs.check_program_mode = n.as<tesseract_collision::CollisionCheckProgramType>();
     return true;
   }
 };
 
+// TODO FIX ENUMS
 
 }  // namespace YAML
 

--- a/tesseract_collision/core/include/tesseract_collision/core/yaml_extensions.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/yaml_extensions.h
@@ -310,8 +310,6 @@ struct convert<tesseract_collision::CollisionCheckConfig>
   }
 };
 
-// TODO FIX ENUMS
-
 }  // namespace YAML
 
 #endif  // TESSERACT_COLLISION_CORE_YAML_EXTENSIONS_H

--- a/tesseract_collision/test/collision_core_unit.cpp
+++ b/tesseract_collision/test/collision_core_unit.cpp
@@ -8,9 +8,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/common.h>
 #include <tesseract_collision/core/types.h>
 #include <tesseract_collision/core/serialization.h>
+#include <tesseract_collision/core/yaml_extensions.h>
 #include <tesseract_common/contact_allowed_validator.h>
 #include <tesseract_common/unit_test_utils.h>
 #include <tesseract_common/utils.h>
+#include <tesseract_common/yaml_utils.h>
 
 class TestContactAllowedValidator : public tesseract_common::ContactAllowedValidator
 {
@@ -143,6 +145,33 @@ TEST(TesseractCoreUnit, ContactManagerConfigTest)  // NOLINT
     config.acm_override_type = tesseract_collision::ACMOverrideType::OR;
     config.acm.addAllowedCollision("a", "b", "never");
     EXPECT_NO_THROW(config.validate());  // NOLINT
+  }
+
+  { // YAML Conversion
+
+    const std::string yaml_string = R"(
+      pair_margin_override_type: NONE
+      acm_override_type: NONE
+    )";
+
+    tesseract_collision::ContactManagerConfig data_original;
+
+    { // decode
+      tesseract_collision::ContactManagerConfig cm;
+      YAML::Node n = YAML::Load(yaml_string);
+      auto success = YAML::convert<tesseract_collision::ContactManagerConfig>::decode(n, cm);
+      EXPECT_TRUE(success);
+      EXPECT_EQ(cm.pair_margin_override_type, data_original.pair_margin_override_type);
+      EXPECT_EQ(cm.acm_override_type, data_original.acm_override_type);
+    }
+
+    { // encode
+      tesseract_collision::ContactManagerConfig cm;
+      YAML::Node n = YAML::Load(yaml_string);
+      YAML::Node output_n = YAML::convert<tesseract_collision::ContactManagerConfig>::encode(cm);
+      EXPECT_EQ(cm.pair_margin_override_type, data_original.pair_margin_override_type);
+      EXPECT_EQ(cm.acm_override_type, data_original.acm_override_type);
+    }
   }
 }
 
@@ -879,6 +908,42 @@ TEST(TesseractCoreUnit, ContactRequestUnit)  // NOLINT
 
     tesseract_common::testSerialization<tesseract_collision::ContactRequest>(request, "ContactRequest");
   }
+
+  { // YAML Conversion
+    const std::string yaml_string = R"(
+      type: ALL
+      calculate_penetration: true
+      calculate_distance: true
+      contact_limit: 0
+    )";
+
+    tesseract_collision::ContactRequest data_original;
+    data_original.type = tesseract_collision::ContactTestType::ALL;
+    data_original.calculate_penetration = true;
+    data_original.calculate_distance = true;
+    data_original.contact_limit = 0;
+
+    { // decode
+      tesseract_collision::ContactRequest cr;
+      YAML::Node n = YAML::Load(yaml_string);
+      auto success = YAML::convert<tesseract_collision::ContactRequest>::decode(n, cr);
+      EXPECT_TRUE(success);
+      EXPECT_EQ(cr.type, data_original.type);
+      EXPECT_EQ(cr.calculate_penetration, data_original.calculate_penetration);
+      EXPECT_EQ(cr.calculate_distance, data_original.calculate_distance);
+      EXPECT_EQ(cr.contact_limit, data_original.contact_limit);
+    }
+
+    { // encode
+      tesseract_collision::ContactRequest cr;
+      YAML::Node n = YAML::Load(yaml_string);
+      YAML::Node output_n = YAML::convert<tesseract_collision::ContactRequest>::encode(cr);
+      EXPECT_EQ(cr.type, data_original.type);
+      EXPECT_EQ(cr.calculate_penetration, data_original.calculate_penetration);
+      EXPECT_EQ(cr.calculate_distance, data_original.calculate_distance);
+      EXPECT_EQ(cr.contact_limit, data_original.contact_limit);
+    }
+  }
 }
 
 TEST(TesseractCoreUnit, CollisionCheckConfigUnit)  // NOLINT
@@ -905,6 +970,54 @@ TEST(TesseractCoreUnit, CollisionCheckConfigUnit)  // NOLINT
     EXPECT_EQ(config.check_program_mode, tesseract_collision::CollisionCheckProgramType::ALL_EXCEPT_START);
 
     tesseract_common::testSerialization<tesseract_collision::CollisionCheckConfig>(config, "CollisionCheckConfig");
+  }
+
+  { // YAML Conversions
+    const std::string contact_request_yaml_string = R"(
+      type: ALL
+      calculate_penetration: true
+      calculate_distance: true
+      contact_limit: 0
+    )";
+
+      const std::string yaml_string = R"(
+      type: DISCRETE
+      longest_valid_segment_length: 0.005
+      check_program_mode: ALL
+    )";
+
+    tesseract_collision::ContactRequest cr_original;
+    cr_original.type = tesseract_collision::ContactTestType::ALL;
+    cr_original.calculate_penetration = true;
+    cr_original.calculate_distance = true;
+    cr_original.contact_limit = 0;
+
+    tesseract_collision::CollisionCheckConfig data_original;
+    data_original.contact_request = cr_original;
+    data_original.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
+    data_original.longest_valid_segment_length = 0.005;
+    data_original.check_program_mode = tesseract_collision::CollisionCheckProgramType::ALL;
+
+    { // decode
+      tesseract_collision::CollisionCheckConfig cr;
+      YAML::Node n = YAML::Load(yaml_string);
+      auto success = YAML::convert<tesseract_collision::CollisionCheckConfig>::decode(n, cr);
+      EXPECT_TRUE(success);
+      EXPECT_EQ(cr.contact_request, data_original.contact_request);
+      EXPECT_EQ(cr.type, data_original.type);
+      EXPECT_EQ(cr.longest_valid_segment_length, data_original.longest_valid_segment_length);
+      EXPECT_EQ(cr.check_program_mode, data_original.check_program_mode);
+    }
+
+    { // encode
+      tesseract_collision::CollisionCheckConfig cr;
+      YAML::Node n = YAML::Load(yaml_string);
+      n["contact_request"] = YAML::Load(contact_request_yaml_string);
+      YAML::Node output_n = YAML::convert<tesseract_collision::CollisionCheckConfig>::encode(cr);
+      EXPECT_EQ(cr.type, data_original.type);
+      EXPECT_EQ(cr.longest_valid_segment_length, data_original.longest_valid_segment_length);
+      EXPECT_EQ(cr.check_program_mode, data_original.check_program_mode);
+    }
   }
 }
 

--- a/tesseract_collision/test/collision_core_unit.cpp
+++ b/tesseract_collision/test/collision_core_unit.cpp
@@ -146,32 +146,33 @@ TEST(TesseractCoreUnit, ContactManagerConfigTest)  // NOLINT
     config.acm.addAllowedCollision("a", "b", "never");
     EXPECT_NO_THROW(config.validate());  // NOLINT
   }
+}
 
-  { // YAML Conversion
+TEST(TesseractCoreUnit, ContactManagerConfigYamlUnit) // NOLINT
+{
 
-    const std::string yaml_string = R"(
-      pair_margin_override_type: NONE
-      acm_override_type: NONE
-    )";
+  const std::string yaml_string = R"(
+    pair_margin_override_type: NONE
+    acm_override_type: NONE
+  )";
 
-    tesseract_collision::ContactManagerConfig data_original;
+  tesseract_collision::ContactManagerConfig data_original;
 
-    { // decode
-      tesseract_collision::ContactManagerConfig cm;
-      YAML::Node n = YAML::Load(yaml_string);
-      auto success = YAML::convert<tesseract_collision::ContactManagerConfig>::decode(n, cm);
-      EXPECT_TRUE(success);
-      EXPECT_EQ(cm.pair_margin_override_type, data_original.pair_margin_override_type);
-      EXPECT_EQ(cm.acm_override_type, data_original.acm_override_type);
-    }
+  { // decode
+    tesseract_collision::ContactManagerConfig cm;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<tesseract_collision::ContactManagerConfig>::decode(n, cm);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(cm.pair_margin_override_type, data_original.pair_margin_override_type);
+    EXPECT_EQ(cm.acm_override_type, data_original.acm_override_type);
+  }
 
-    { // encode
-      tesseract_collision::ContactManagerConfig cm;
-      YAML::Node n = YAML::Load(yaml_string);
-      YAML::Node output_n = YAML::convert<tesseract_collision::ContactManagerConfig>::encode(cm);
-      EXPECT_EQ(cm.pair_margin_override_type, data_original.pair_margin_override_type);
-      EXPECT_EQ(cm.acm_override_type, data_original.acm_override_type);
-    }
+  { // encode
+    tesseract_collision::ContactManagerConfig cm;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<tesseract_collision::ContactManagerConfig>::encode(cm);
+    EXPECT_EQ(cm.pair_margin_override_type, data_original.pair_margin_override_type);
+    EXPECT_EQ(cm.acm_override_type, data_original.acm_override_type);
   }
 }
 
@@ -908,41 +909,42 @@ TEST(TesseractCoreUnit, ContactRequestUnit)  // NOLINT
 
     tesseract_common::testSerialization<tesseract_collision::ContactRequest>(request, "ContactRequest");
   }
+}
 
-  { // YAML Conversion
-    const std::string yaml_string = R"(
-      type: ALL
-      calculate_penetration: true
-      calculate_distance: true
-      contact_limit: 0
-    )";
+TEST(TesseractCoreUnit, ContactRequestYamlUnit) // NOLINT
+{
+  const std::string yaml_string = R"(
+    type: ALL
+    calculate_penetration: true
+    calculate_distance: true
+    contact_limit: 0
+  )";
 
-    tesseract_collision::ContactRequest data_original;
-    data_original.type = tesseract_collision::ContactTestType::ALL;
-    data_original.calculate_penetration = true;
-    data_original.calculate_distance = true;
-    data_original.contact_limit = 0;
+  tesseract_collision::ContactRequest data_original;
+  data_original.type = tesseract_collision::ContactTestType::ALL;
+  data_original.calculate_penetration = true;
+  data_original.calculate_distance = true;
+  data_original.contact_limit = 0;
 
-    { // decode
-      tesseract_collision::ContactRequest cr;
-      YAML::Node n = YAML::Load(yaml_string);
-      auto success = YAML::convert<tesseract_collision::ContactRequest>::decode(n, cr);
-      EXPECT_TRUE(success);
-      EXPECT_EQ(cr.type, data_original.type);
-      EXPECT_EQ(cr.calculate_penetration, data_original.calculate_penetration);
-      EXPECT_EQ(cr.calculate_distance, data_original.calculate_distance);
-      EXPECT_EQ(cr.contact_limit, data_original.contact_limit);
-    }
+  { // decode
+    tesseract_collision::ContactRequest cr;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<tesseract_collision::ContactRequest>::decode(n, cr);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(cr.type, data_original.type);
+    EXPECT_EQ(cr.calculate_penetration, data_original.calculate_penetration);
+    EXPECT_EQ(cr.calculate_distance, data_original.calculate_distance);
+    EXPECT_EQ(cr.contact_limit, data_original.contact_limit);
+  }
 
-    { // encode
-      tesseract_collision::ContactRequest cr;
-      YAML::Node n = YAML::Load(yaml_string);
-      YAML::Node output_n = YAML::convert<tesseract_collision::ContactRequest>::encode(cr);
-      EXPECT_EQ(cr.type, data_original.type);
-      EXPECT_EQ(cr.calculate_penetration, data_original.calculate_penetration);
-      EXPECT_EQ(cr.calculate_distance, data_original.calculate_distance);
-      EXPECT_EQ(cr.contact_limit, data_original.contact_limit);
-    }
+  { // encode
+    tesseract_collision::ContactRequest cr;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<tesseract_collision::ContactRequest>::encode(cr);
+    EXPECT_EQ(cr.type, data_original.type);
+    EXPECT_EQ(cr.calculate_penetration, data_original.calculate_penetration);
+    EXPECT_EQ(cr.calculate_distance, data_original.calculate_distance);
+    EXPECT_EQ(cr.contact_limit, data_original.contact_limit);
   }
 }
 
@@ -971,53 +973,54 @@ TEST(TesseractCoreUnit, CollisionCheckConfigUnit)  // NOLINT
 
     tesseract_common::testSerialization<tesseract_collision::CollisionCheckConfig>(config, "CollisionCheckConfig");
   }
+}
 
-  { // YAML Conversions
-    const std::string contact_request_yaml_string = R"(
-      type: ALL
-      calculate_penetration: true
-      calculate_distance: true
-      contact_limit: 0
-    )";
+TEST(TesseractCoreUnit, CollisionCheckConfigYamlUnit) // NOLINT
+{
+  const std::string contact_request_yaml_string = R"(
+    type: ALL
+    calculate_penetration: true
+    calculate_distance: true
+    contact_limit: 0
+  )";
 
-      const std::string yaml_string = R"(
-      type: DISCRETE
-      longest_valid_segment_length: 0.005
-      check_program_mode: ALL
-    )";
+    const std::string yaml_string = R"(
+    type: DISCRETE
+    longest_valid_segment_length: 0.005
+    check_program_mode: ALL
+  )";
 
-    tesseract_collision::ContactRequest cr_original;
-    cr_original.type = tesseract_collision::ContactTestType::ALL;
-    cr_original.calculate_penetration = true;
-    cr_original.calculate_distance = true;
-    cr_original.contact_limit = 0;
+  tesseract_collision::ContactRequest cr_original;
+  cr_original.type = tesseract_collision::ContactTestType::ALL;
+  cr_original.calculate_penetration = true;
+  cr_original.calculate_distance = true;
+  cr_original.contact_limit = 0;
 
-    tesseract_collision::CollisionCheckConfig data_original;
-    data_original.contact_request = cr_original;
-    data_original.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
-    data_original.longest_valid_segment_length = 0.005;
-    data_original.check_program_mode = tesseract_collision::CollisionCheckProgramType::ALL;
+  tesseract_collision::CollisionCheckConfig data_original;
+  data_original.contact_request = cr_original;
+  data_original.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
+  data_original.longest_valid_segment_length = 0.005;
+  data_original.check_program_mode = tesseract_collision::CollisionCheckProgramType::ALL;
 
-    { // decode
-      tesseract_collision::CollisionCheckConfig cr;
-      YAML::Node n = YAML::Load(yaml_string);
-      auto success = YAML::convert<tesseract_collision::CollisionCheckConfig>::decode(n, cr);
-      EXPECT_TRUE(success);
-      EXPECT_EQ(cr.contact_request, data_original.contact_request);
-      EXPECT_EQ(cr.type, data_original.type);
-      EXPECT_EQ(cr.longest_valid_segment_length, data_original.longest_valid_segment_length);
-      EXPECT_EQ(cr.check_program_mode, data_original.check_program_mode);
-    }
+  { // decode
+    tesseract_collision::CollisionCheckConfig cr;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<tesseract_collision::CollisionCheckConfig>::decode(n, cr);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(cr.contact_request, data_original.contact_request);
+    EXPECT_EQ(cr.type, data_original.type);
+    EXPECT_EQ(cr.longest_valid_segment_length, data_original.longest_valid_segment_length);
+    EXPECT_EQ(cr.check_program_mode, data_original.check_program_mode);
+  }
 
-    { // encode
-      tesseract_collision::CollisionCheckConfig cr;
-      YAML::Node n = YAML::Load(yaml_string);
-      n["contact_request"] = YAML::Load(contact_request_yaml_string);
-      YAML::Node output_n = YAML::convert<tesseract_collision::CollisionCheckConfig>::encode(cr);
-      EXPECT_EQ(cr.type, data_original.type);
-      EXPECT_EQ(cr.longest_valid_segment_length, data_original.longest_valid_segment_length);
-      EXPECT_EQ(cr.check_program_mode, data_original.check_program_mode);
-    }
+  { // encode
+    tesseract_collision::CollisionCheckConfig cr;
+    YAML::Node n = YAML::Load(yaml_string);
+    n["contact_request"] = YAML::Load(contact_request_yaml_string);
+    YAML::Node output_n = YAML::convert<tesseract_collision::CollisionCheckConfig>::encode(cr);
+    EXPECT_EQ(cr.type, data_original.type);
+    EXPECT_EQ(cr.longest_valid_segment_length, data_original.longest_valid_segment_length);
+    EXPECT_EQ(cr.check_program_mode, data_original.check_program_mode);
   }
 }
 


### PR DESCRIPTION
Adds in YAML conversions for `ContactManagerConfig` and `CollisionCheckConfig` and unit tests for YAML functions.